### PR TITLE
Fixing impl class overwriting issue when code regeneration

### DIFF
--- a/src/main/java/org/wso2/maven/plugins/JavaMSF4JServerCodegen.java
+++ b/src/main/java/org/wso2/maven/plugins/JavaMSF4JServerCodegen.java
@@ -189,4 +189,9 @@ public class JavaMSF4JServerCodegen extends AbstractJavaJAXRSServerCodegen {
         co.baseName = basePath;
     }
 
+    @Override
+    public boolean shouldOverwrite(String filename) {
+        String implSourcePattern = ".*/impl/.*ServiceImpl\\.java$";
+        return !filename.matches(implSourcePattern) && super.shouldOverwrite(filename);
+    }
 }


### PR DESCRIPTION
Sources under /impl are getting generated again when we are regenerating code from swagger. That will overwrite the code we write on those classes. They should be generated only once (Only if the file is not there).