### PR TITLE
Fix code generation for no params, no vars scenarios

### DIFF
--- a/src/main/resources/MSF4J/api.mustache
+++ b/src/main/resources/MSF4J/api.mustache
@@ -59,9 +59,9 @@ public class {{classname}} implements Microservice  {
     @io.swagger.annotations.ApiResponses(value = { {{#responses}}
         @io.swagger.annotations.ApiResponse(code = {{{code}}}, message = "{{{message}}}", response = {{{returnType}}}.class{{#returnContainer}}, responseContainer = "{{{returnContainer}}}"{{/returnContainer}}){{#hasMore}},
         {{/hasMore}}{{/responses}} })
-    public Response {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},{{/hasMore}}{{/allParams}}, @Context Request request)
+    public Response {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},{{/hasMore}}{{/allParams}} {{#hasParams}},{{/hasParams}}@Context Request request)
     throws NotFoundException {
-        return delegate.{{nickname}}({{#allParams}}{{#isFile}}{{paramName}}InputStream, {{paramName}}Detail{{/isFile}}{{^isFile}}{{paramName}}{{/isFile}}{{#hasMore}},{{/hasMore}}{{/allParams}}, request);
+        return delegate.{{nickname}}({{#allParams}}{{#isFile}}{{paramName}}InputStream, {{paramName}}Detail{{/isFile}}{{^isFile}}{{paramName}}{{/isFile}}{{#hasMore}},{{/hasMore}}{{/allParams}}{{#hasParams}},{{/hasParams}}request);
     }
 {{/operation}}
 }

--- a/src/main/resources/MSF4J/apiService.mustache
+++ b/src/main/resources/MSF4J/apiService.mustache
@@ -21,7 +21,7 @@ import javax.ws.rs.core.SecurityContext;
 {{#operations}}
 public abstract class {{classname}}Service {
     {{#operation}}
-    public abstract Response {{nickname}}({{#allParams}}{{>serviceQueryParams}}{{>servicePathParams}}{{>serviceHeaderParams}}{{>serviceBodyParams}}{{>serviceFormParams}} {{#hasMore}},{{/hasMore}}{{/allParams}}, Request request) throws NotFoundException;
+    public abstract Response {{nickname}}({{#allParams}}{{>serviceQueryParams}}{{>servicePathParams}}{{>serviceHeaderParams}}{{>serviceBodyParams}}{{>serviceFormParams}} {{#hasMore}},{{/hasMore}}{{/allParams}} {{#hasParams}},{{/hasParams}}Request request) throws NotFoundException;
     {{/operation}}
 }
 {{/operations}}

--- a/src/main/resources/MSF4J/apiServiceImpl.mustache
+++ b/src/main/resources/MSF4J/apiServiceImpl.mustache
@@ -19,7 +19,7 @@ import javax.ws.rs.core.SecurityContext;
 public class {{classname}}ServiceImpl extends {{classname}}Service {
     {{#operation}}
     @Override
-    public Response {{nickname}}({{#allParams}}{{>serviceQueryParams}}{{>servicePathParams}}{{>serviceHeaderParams}}{{>serviceBodyParams}}{{>serviceFormParams}}{{#hasMore}},{{/hasMore}} {{/allParams}}, Request request) throws NotFoundException {
+    public Response {{nickname}}({{#allParams}}{{>serviceQueryParams}}{{>servicePathParams}}{{>serviceHeaderParams}}{{>serviceBodyParams}}{{>serviceFormParams}}{{#hasMore}},{{/hasMore}} {{/allParams}} {{#hasParams}},{{/hasParams}}Request request) throws NotFoundException {
         // do some magic!
         return Response.ok().entity(new ApiResponseMessage(ApiResponseMessage.OK, "magic!")).build();
     }

--- a/src/main/resources/MSF4J/pojo.mustache
+++ b/src/main/resources/MSF4J/pojo.mustache
@@ -108,6 +108,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
     return sb.toString();
   }
 
+  {{#hasVars}}
   /**
    * Convert the given object to string with each line indented by 4 spaces
    * (except the first line).
@@ -118,4 +119,5 @@ public class {{classname}} {{#parent}}extends {{{parent}}}{{/parent}} {{#seriali
     }
     return o.toString().replace("\n", "\n    ");
   }
+  {{/hasVars}}
 }


### PR DESCRIPTION
This PR include below fixes.
- Fix api, apiService and apiServiceImpl mustache to check for params when generating the method arguments.
- Fix pojo mustache to generate 'toIndentedString' method only when there are variables in the DTO. This is because 'toIndentedString' is invoked only if there are variables. 