### PR TITLE
Upgrade swagger-codegen version to 2.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,12 @@
     <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-codegen</artifactId>
-      <version>2.2.2</version>
+      <version>2.2.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-project</artifactId>
+      <version>2.2.1</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
This PR is to upgrade the swagger-codegen 2.2.2 to swagger-codegen 2.2.3
The following extra dependency was added:
```
    <dependency>
      <groupId>org.apache.maven</groupId>
      <artifactId>maven-project</artifactId>
      <version>2.2.1</version>
    </dependency>
```