### PR TITLE
Supporting default values in API service params

### DIFF
--- a/src/main/resources/MSF4J/api.mustache
+++ b/src/main/resources/MSF4J/api.mustache
@@ -64,6 +64,8 @@ public class {{classname}} implements Microservice  {
         {{/hasMore}}{{/responses}} })
     public Response {{nickname}}({{#allParams}}{{>queryParams}}{{>pathParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}},{{/hasMore}}{{/allParams}} {{#hasParams}},{{/hasParams}}@Context Request request)
     throws NotFoundException {
+        {{#allParams}}{{#defaultValue}}{{paramName}}={{paramName}}==null?{{{dataType}}}.valueOf("{{defaultValue}}"):{{paramName}};
+        {{/defaultValue}}{{/allParams}}
         return delegate.{{nickname}}({{#allParams}}{{#isFile}}{{paramName}}InputStream, {{paramName}}Detail{{/isFile}}{{^isFile}}{{paramName}}{{/isFile}}{{#hasMore}},{{/hasMore}}{{/allParams}}{{#hasParams}},{{/hasParams}}request);
     }
 {{/operation}}


### PR DESCRIPTION
``` 
  # Endpoint uses to get all the available scopes
   get:
     description: |
        This API is used to get all the available scopes.
     parameters:
       -
         name: offset
         in: query
         description: start index of the list of scopes to be retrieved
         required: false
         default: 0
         type: integer
       -
         name: limit
         in: query
         description: a limited number of scopes to be retrieved
         required: false
         default: 25
         type: integer
```

Generated method with default values for `limit` and `offset` parameters.

```
    public Response getScopes(@ApiParam(value = "start index of the list of scopes to be retrieved", defaultValue="0") @DefaultValue("0") @QueryParam("offset") Integer offset
,@ApiParam(value = "a limited number of scopes to be retrieved", defaultValue="25") @DefaultValue("25") @QueryParam("limit") Integer limit
 ,@Context Request request)
    throws NotFoundException {
        offset = (offset == null ? Integer.valueOf("0"):offset);
        limit = (limit == null ? Integer.valueOf("25"):limit);
        
        return delegate.getScopes(offset,limit,request);
    }
```